### PR TITLE
fix: EOA Behaviour Mismatch

### DIFF
--- a/src/Pectra.sol
+++ b/src/Pectra.sol
@@ -46,7 +46,11 @@ contract Pectra {
         return this.onERC1155Received.selector;
     }
 
-    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata) external pure returns (bytes4) {
+    function onERC1155BatchReceived(address, address, uint256[] calldata, uint256[] calldata, bytes calldata)
+        external
+        pure
+        returns (bytes4)
+    {
         return this.onERC1155BatchReceived.selector;
     }
 


### PR DESCRIPTION
#8 
Although the contract is not supposed to be delegated perpetually, we've added the required functionalities just in case some EOA interaction happens while the user is performing validator actions using EIP-7702 (EOA is still delegated to the Pectra contract) and the delegation is not unset.